### PR TITLE
Resolved Issues #43, #39, #38

### DIFF
--- a/GUI/ShopCursor.gd
+++ b/GUI/ShopCursor.gd
@@ -79,7 +79,7 @@ func _set_target(node: Control) -> void:
 	global_position = target.global_position + OFFSET
 	show()
 	set_process(true)
-	if not suppress_next_move_sound and move_sound.stream:
+	if not suppress_next_move_sound and move_sound.stream and move_sound.is_inside_tree():
 		move_sound.play()
 	suppress_next_move_sound = false
 

--- a/GUI/ShopUI.gd
+++ b/GUI/ShopUI.gd
@@ -5,17 +5,17 @@ signal item_purchased(item: Item, amount: int) # Emitted when an item is bought
 signal item_selected(item: Item) # Emitted when an item is selected
 
 # UI references
-@onready var shopui              : ShopUI           = $"."
-@onready var startui             : StartUI          = $StartUI
-@onready var shop_cursor         : ShopCursor       = $ShopCursor
-@onready var buy_button          : Button           = $MarginContainer/Window/VBoxContainer/Top/Select/MarginContainer/HBoxContainer/Buy
-@onready var buy_header_row      : HBoxContainer    = $MarginContainer/Window/VBoxContainer/Middle/MarginContainer/Buy/BuyHeader
-@onready var buy_list            : VBoxContainer    = $MarginContainer/Window/VBoxContainer/Middle/MarginContainer/Buy/BuyScroll/BuyList
-@onready var sell_header_row     : HBoxContainer    = $MarginContainer/Window/VBoxContainer/Middle/MarginContainer/Sell/SellHeader
-@onready var sell_list           : VBoxContainer    = $MarginContainer/Window/VBoxContainer/Middle/MarginContainer/Sell/SellScroll/SellList
-@onready var sell_button         : Button           = $MarginContainer/Window/VBoxContainer/Top/Select/MarginContainer/HBoxContainer/Sell
-@onready var exit_button         : Button           = $MarginContainer/Window/VBoxContainer/Top/Select/MarginContainer/HBoxContainer/Exit
-@onready var detail_label        : Label            = $MarginContainer/Window/VBoxContainer/Bottom/ItemDetail/MarginContainer/Detail
+@onready var shopui              :ShopUI           = $"."
+@onready var startui             :StartUI          = get_node_or_null("StartUI")
+@onready var shop_cursor         :ShopCursor       = $ShopCursor
+@onready var buy_button          :Button           = $MarginContainer/Window/VBoxContainer/Top/Select/MarginContainer/HBoxContainer/Buy
+@onready var buy_header_row      :HBoxContainer    = $MarginContainer/Window/VBoxContainer/Middle/MarginContainer/Buy/BuyHeader
+@onready var buy_list            :VBoxContainer    = $MarginContainer/Window/VBoxContainer/Middle/MarginContainer/Buy/BuyScroll/BuyList
+@onready var sell_header_row     :HBoxContainer    = $MarginContainer/Window/VBoxContainer/Middle/MarginContainer/Sell/SellHeader
+@onready var sell_list           :VBoxContainer    = $MarginContainer/Window/VBoxContainer/Middle/MarginContainer/Sell/SellScroll/SellList
+@onready var sell_button         :Button           = $MarginContainer/Window/VBoxContainer/Top/Select/MarginContainer/HBoxContainer/Sell
+@onready var exit_button         :Button           = $MarginContainer/Window/VBoxContainer/Top/Select/MarginContainer/HBoxContainer/Exit
+@onready var detail_label        :Label            = $MarginContainer/Window/VBoxContainer/Bottom/ItemDetail/MarginContainer/Detail
 
 const Item = preload("res://Items/Item.gd")
 

--- a/GUI/StartUI.gd
+++ b/GUI/StartUI.gd
@@ -69,7 +69,13 @@ func _process(_delta):
 
 func _unhandled_input(event):
 	if event.is_action_pressed("ui_cancel"):
-		if menu_state == "character_select":
+		# NEW
+		if menu_state == "main":
+			# When in the StartMenu, close entire StartUI
+			close_menu()
+		# EXISTING
+		elif menu_state == "character_select":
+			# When selecting a character (from Equip), cancel should return to StartMenu without closing StartUI
 			menu_state = "main"
 			start_menu.visible = true
 			start_menu.modulate = Color(1,1,1,1)
@@ -103,6 +109,7 @@ func close_menu():
 	start_cursor.visible = false
 	startui.visible = false
 	TextUi.show()
+	Globals.player.movement_locked = false # <----- NEW
 	#DEBUG print("StartUI.gd/close_menu -> Menu: ", menu_state)
 
 func get_current_money():
@@ -216,7 +223,6 @@ func _on_character_slot_selected(index):
 func _on_equipmenu_cancel():
 	#DEBUG print("StartUI.gd/_on_equipmenu_cancel() called")
 	if menu_state == "equip_menu":
-		menu_state = "main"
 		equip_menu.visible = false
 		start_menu.visible = true
 		equip_button.grab_focus()
@@ -224,6 +230,7 @@ func _on_equipmenu_cancel():
 		anim_player.play("fade_in")
 		await anim_player.animation_finished
 		start_menu.modulate = Color(1,1,1,1)
+		menu_state = "main" # <----- NEW - Fixes issue with pressing ui_cancel in EquipMenu and backing out of StartUI completely
 	#DEBUG print("StartUI.gd/_on_equipment_cancel -> Menu: ", menu_state)
 
 func _on_check_pressed():

--- a/GUI/UseMenu.gd
+++ b/GUI/UseMenu.gd
@@ -24,7 +24,7 @@ func _unhandled_input(event):
 	if event.is_action_pressed("ui_down") or event.is_action_pressed("ui_up"):
 		#DEBUG print("UseMenu.gd/_unhandled_input -> Focus owner is now: ", get_viewport().gui_get_focus_owner())
 		pass
-	if event.is_action_pressed("ui_cancel") and self.visible:
+	if event.is_action_pressed("ui_cancel") and visible:
 		#DEBUG print("UseMenu.gd/_unhandled_input -> ui_cancel pressed in UseMenu!")
 		emit_signal("cancelled")
 		get_viewport().set_input_as_handled()


### PR DESCRIPTION
Added cancel behavior for Skill and target selection in Battle.gd to prevent unintended skill casting.

Improved StartUI.gd to properly unlock player movement and handle menu state transitions when cancelling from EquipMenu or StartMenu.

Fixed ShopCursor.gd to check if move_sound is inside the scene tree before playing.

Minor cleanup in UseMenu.gd for cancel input handling.